### PR TITLE
[이창환] QnA 4단계(객체지향개발) 구현 완료

### DIFF
--- a/src/main/java/codesquad/domain/Answer.java
+++ b/src/main/java/codesquad/domain/Answer.java
@@ -1,5 +1,6 @@
 package codesquad.domain;
 
+import codesquad.UnAuthorizedException;
 import support.domain.AbstractEntity;
 import support.domain.UrlGeneratable;
 
@@ -59,8 +60,12 @@ public class Answer extends AbstractEntity implements UrlGeneratable {
         this.question = question;
     }
 
-    public void delete() {
+    public Long delete(User loginUser) {
+        if(!isOwner(loginUser)) {
+            throw new UnAuthorizedException("mismatch answer owner");
+        }
         this.deleted = true;
+        return getId();
     }
 
     public boolean isOwner(User loginUser) {

--- a/src/main/java/codesquad/domain/Answer.java
+++ b/src/main/java/codesquad/domain/Answer.java
@@ -6,6 +6,7 @@ import support.domain.UrlGeneratable;
 
 import javax.persistence.*;
 import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
 
 @Entity
 public class Answer extends AbstractEntity implements UrlGeneratable {
@@ -60,12 +61,12 @@ public class Answer extends AbstractEntity implements UrlGeneratable {
         this.question = question;
     }
 
-    public Long delete(User loginUser) {
-        if(!isOwner(loginUser)) {
+    public DeleteHistory delete(User loginUser) {
+        if (!isOwner(loginUser)) {
             throw new UnAuthorizedException("mismatch answer owner");
         }
         this.deleted = true;
-        return getId();
+        return new DeleteHistory(ContentType.ANSWER, getId(), loginUser, LocalDateTime.now());
     }
 
     public boolean isOwner(User loginUser) {

--- a/src/main/java/codesquad/domain/Question.java
+++ b/src/main/java/codesquad/domain/Question.java
@@ -98,7 +98,7 @@ public class Question extends AbstractEntity implements UrlGeneratable {
         List<DeleteHistory> histories = new ArrayList<>();
 
         for (Answer answer : answers) {
-            histories.add(new DeleteHistory(ContentType.ANSWER, answer.delete(loginUser), loginUser, LocalDateTime.now()));
+            histories.add(answer.delete(loginUser));
         }
 
         if (!isOwner(loginUser)) {

--- a/src/main/java/codesquad/domain/Question.java
+++ b/src/main/java/codesquad/domain/Question.java
@@ -1,11 +1,13 @@
 package codesquad.domain;
 
+import codesquad.UnAuthorizedException;
 import org.hibernate.annotations.Where;
 import support.domain.AbstractEntity;
 import support.domain.UrlGeneratable;
 
 import javax.persistence.*;
 import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -92,7 +94,19 @@ public class Question extends AbstractEntity implements UrlGeneratable {
         this.contents = updatedQuestion.getContents();
     }
 
-    public void delete() {
+    public List<DeleteHistory> delete(User loginUser) {
+        List<DeleteHistory> histories = new ArrayList<>();
+
+        for (Answer answer : answers) {
+            histories.add(new DeleteHistory(ContentType.ANSWER, answer.delete(loginUser), loginUser, LocalDateTime.now()));
+        }
+
+        if (!isOwner(loginUser)) {
+            throw new UnAuthorizedException("mismatch question writer");
+        }
         this.deleted = true;
+        histories.add(new DeleteHistory(ContentType.QUESTION, getId(), loginUser, LocalDateTime.now()));
+
+        return histories;
     }
 }

--- a/src/main/java/codesquad/domain/Question.java
+++ b/src/main/java/codesquad/domain/Question.java
@@ -97,12 +97,12 @@ public class Question extends AbstractEntity implements UrlGeneratable {
     public List<DeleteHistory> delete(User loginUser) {
         List<DeleteHistory> histories = new ArrayList<>();
 
-        for (Answer answer : answers) {
-            histories.add(answer.delete(loginUser));
-        }
-
         if (!isOwner(loginUser)) {
             throw new UnAuthorizedException("mismatch question writer");
+        }
+
+        for (Answer answer : answers) {
+            histories.add(answer.delete(loginUser));
         }
         this.deleted = true;
         histories.add(new DeleteHistory(ContentType.QUESTION, getId(), loginUser, LocalDateTime.now()));

--- a/src/main/java/codesquad/security/SecurityControllerAdvice.java
+++ b/src/main/java/codesquad/security/SecurityControllerAdvice.java
@@ -1,5 +1,6 @@
 package codesquad.security;
 
+import codesquad.CannotDeleteException;
 import codesquad.UnAuthenticationException;
 import codesquad.UnAuthorizedException;
 import org.slf4j.Logger;

--- a/src/main/java/codesquad/service/QnaService.java
+++ b/src/main/java/codesquad/service/QnaService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Resource;
+import javax.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Optional;
 
@@ -52,13 +53,10 @@ public class QnaService {
     @Transactional
     public Question deleteQuestion(User loginUser, Long id) {
         Question question = questionRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("question not found"));
+                .orElseThrow(() -> new EntityNotFoundException("question not found"));
 
-        if (!question.isOwner(loginUser)) {
-            throw new UnAuthorizedException("mismatch writer");
-        }
+        deleteHistoryService.saveAll(question.delete(loginUser));
 
-        question.delete();
         return questionRepository.save(question);
     }
 
@@ -73,20 +71,16 @@ public class QnaService {
     public Answer addAnswer(User loginUser, Long questionId, String contents) {
         Answer answer = new Answer(loginUser, contents);
         answer.toQuestion(questionRepository.findById(questionId)
-                .orElseThrow(() -> new RuntimeException("question not found")));
+                .orElseThrow(() -> new EntityNotFoundException("question not found")));
 
         return answerRepository.save(answer);
     }
 
     public Answer deleteAnswer(User loginUser, Long id) {
         Answer answer = answerRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("answer not found"));
+                .orElseThrow(() -> new EntityNotFoundException("answer not found"));
 
-        if (!answer.isOwner(loginUser)) {
-            throw new UnAuthorizedException("mismatch writer");
-        }
-
-        answer.delete();
+        answer.delete(loginUser);
         return answerRepository.save(answer);
     }
 }

--- a/src/main/java/codesquad/service/QnaService.java
+++ b/src/main/java/codesquad/service/QnaService.java
@@ -73,6 +73,7 @@ public class QnaService {
                 .orElseThrow(() -> new EntityNotFoundException("question not found")));
 
         return answerRepository.save(answer);
+
     }
 
     public Answer deleteAnswer(User loginUser, Long id) {

--- a/src/main/java/codesquad/service/QnaService.java
+++ b/src/main/java/codesquad/service/QnaService.java
@@ -1,6 +1,5 @@
 package codesquad.service;
 
-import codesquad.CannotDeleteException;
 import codesquad.UnAuthorizedException;
 import codesquad.domain.*;
 import org.slf4j.Logger;
@@ -40,7 +39,7 @@ public class QnaService {
     @Transactional
     public Question update(User loginUser, Long id, Question updateQuestion) {
         Question question = questionRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("question not found"));
+                .orElseThrow(() -> new EntityNotFoundException("question not found"));
 
         if (!question.isOwner(loginUser)) {
             throw new UnAuthorizedException("mismatch writer");

--- a/src/main/java/codesquad/web/ApiQuestionController.java
+++ b/src/main/java/codesquad/web/ApiQuestionController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.persistence.EntityNotFoundException;
 import java.net.URI;
 
 @RestController
@@ -31,7 +32,7 @@ public class ApiQuestionController {
     @GetMapping("/{id}")
     public Question show(@PathVariable Long id) {
         return qnaService.findById(id)
-                .orElseThrow(() -> new RuntimeException("question not found"));
+                .orElseThrow(() -> new EntityNotFoundException("question not found"));
     }
 
     @PutMapping("/{id}")

--- a/src/test/java/codesquad/domain/QuestionTest.java
+++ b/src/test/java/codesquad/domain/QuestionTest.java
@@ -1,0 +1,48 @@
+package codesquad.domain;
+
+import codesquad.UnAuthorizedException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static codesquad.domain.UserTest.JAVAJIGI;
+import static codesquad.domain.UserTest.SANJIGI;
+
+public class QuestionTest {
+    private Question question;
+
+    @Before
+    public void setUp() {
+        question = new Question("title", "contents");
+        question.writeBy(JAVAJIGI);
+    }
+
+    @After
+    public void cleanUp() {
+        question = null;
+    }
+
+    @Test
+    public void delete_성공_같은_질문작성자() {
+        question.delete(JAVAJIGI);
+    }
+
+    @Test
+    public void delete_성공_같은_질문작성자_같은_답변작성자() {
+        question.addAnswer(new Answer(JAVAJIGI, "contents"));
+
+        question.delete(JAVAJIGI);
+    }
+
+    @Test(expected = UnAuthorizedException.class)
+    public void delete_실패_다른_질문작성자() {
+        question.delete(SANJIGI);
+    }
+
+    @Test(expected = UnAuthorizedException.class)
+    public void delete_실패_같은_질문작성자_다른_답변작성자() {
+        question.addAnswer(new Answer(SANJIGI, "contents1"));
+
+        question.delete(JAVAJIGI);
+    }
+}

--- a/src/test/java/codesquad/domain/QuestionTest.java
+++ b/src/test/java/codesquad/domain/QuestionTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import static codesquad.domain.UserTest.JAVAJIGI;
 import static codesquad.domain.UserTest.SANJIGI;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class QuestionTest {
     private Question question;
@@ -25,6 +26,7 @@ public class QuestionTest {
     @Test
     public void delete_성공_같은_질문작성자() {
         question.delete(JAVAJIGI);
+        assertThat(question.isDeleted()).isTrue();
     }
 
     @Test
@@ -32,6 +34,7 @@ public class QuestionTest {
         question.addAnswer(new Answer(JAVAJIGI, "contents"));
 
         question.delete(JAVAJIGI);
+        assertThat(question.isDeleted()).isTrue();
     }
 
     @Test(expected = UnAuthorizedException.class)


### PR DESCRIPTION
- ApiQuestionAcceptanceTest의 delete 실패할 여러경우 추가
- delete 핵심 로직을 question 도메인에 구현
- delete 메소드에 대해 단위테스트 QuestionTest에 작성
- 기존에 도메인이 없을 경우 발생 시켰던 RuntimeException을 EntityNotFoundException으로 교체