### PR TITLE
[2단계] 구현 완료했습니다. 리뷰 부탁드립니다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ repositories {
 
 dependencies {
     implementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+    testImplementation 'org.mockito:mockito-junit-jupiter:3.11.2'
+    compile group: 'org.mockito', name: 'mockito-core', version: '2.22.0'
     compile('org.springframework.boot:spring-boot-starter-data-jpa')
     compile('org.springframework.boot:spring-boot-starter-web')
     compile('org.hibernate:hibernate-java8')

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.junit.jupiter:junit-jupiter:5.8.1'
     compile('org.springframework.boot:spring-boot-starter-data-jpa')
     compile('org.springframework.boot:spring-boot-starter-web')
     compile('org.hibernate:hibernate-java8')

--- a/src/main/java/codesquad/domain/Question.java
+++ b/src/main/java/codesquad/domain/Question.java
@@ -19,9 +19,17 @@ public class Question extends AbstractEntity implements UrlGeneratable {
     @Lob
     private String contents;
 
+    public void setWriter(User writer) {
+        this.writer = writer;
+    }
+
     @ManyToOne
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_question_writer"))
     private User writer;
+
+    public void setDeleted(boolean deleted) {
+        this.deleted = deleted;
+    }
 
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
     @Where(clause = "deleted = false")
@@ -75,6 +83,13 @@ public class Question extends AbstractEntity implements UrlGeneratable {
 
     public boolean isDeleted() {
         return deleted;
+    }
+
+    public Question update(Question question) {
+        this.title = question.getTitle();
+        this.contents = question.getContents();
+
+        return this;
     }
 
     @Override

--- a/src/main/java/codesquad/service/QnaService.java
+++ b/src/main/java/codesquad/service/QnaService.java
@@ -11,7 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.annotation.Resource;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
 @Service("qnaService")
 public class QnaService {
@@ -31,7 +30,7 @@ public class QnaService {
 
     public Question create(User loginUser, Question question) {
         question.writeBy(loginUser);
-        log.debug("question : {}", question);
+        log.debug("QnaService question ={}", question.getWriter());
         return questionRepository.save(question);
     }
 
@@ -41,12 +40,15 @@ public class QnaService {
     }
 
     @Transactional
-    public Question update(User loginUser, long id, Question updatedQuestion) {
+    public Question update(User loginUser, long id, Question newQuestion) {
         // TODO 수정 기능 구현
-        Question question = questionRepository.findById(id).filter(s -> s.getWriter()
-                                                      .equals(loginUser))
-                                        .orElseThrow(NoSuchElementException::new);
-        return question.update(updatedQuestion);
+        Question question = questionRepository.findById(id)
+                                              .filter(s -> s.getWriter()
+                                                            .equals(loginUser))
+                                              .orElseThrow(NoSuchElementException::new);
+
+        log.debug("QnaService update() question.getWriter() ={}", question.getWriter());
+        return question.update(newQuestion);
     }
 
     @Transactional
@@ -56,6 +58,7 @@ public class QnaService {
                                               .filter(s -> s.getWriter()
                                                             .equals(loginUser))
                                               .orElseThrow(NoSuchElementException::new);
+        log.debug("QnaService deleteQuestion setDeleted() called");
         question.setDeleted(true);
         questionRepository.delete(question);
     }

--- a/src/main/java/codesquad/service/QnaService.java
+++ b/src/main/java/codesquad/service/QnaService.java
@@ -17,8 +17,7 @@ import java.util.Optional;
 public class QnaService {
     private static final Logger log = LoggerFactory.getLogger(QnaService.class);
 
-    @Resource(name = "questionRepository")
-    private QuestionRepository questionRepository;
+    private final QuestionRepository questionRepository;
 
     @Resource(name = "answerRepository")
     private AnswerRepository answerRepository;
@@ -26,20 +25,25 @@ public class QnaService {
     @Resource(name = "deleteHistoryService")
     private DeleteHistoryService deleteHistoryService;
 
+    public QnaService(QuestionRepository questionRepository) {
+        this.questionRepository = questionRepository;
+    }
+
     public Question create(User loginUser, Question question) {
         question.writeBy(loginUser);
         log.debug("question : {}", question);
         return questionRepository.save(question);
     }
 
-    public Optional<Question> findById(long id) {
-        return questionRepository.findById(id);
+    public Question findById(long id) {
+        return questionRepository.findById(id)
+                                 .orElseThrow(NoSuchElementException::new);
     }
 
     @Transactional
     public Question update(User loginUser, long id, Question updatedQuestion) {
         // TODO 수정 기능 구현
-        Question question = findById(id).filter(s -> s.getWriter()
+        Question question = questionRepository.findById(id).filter(s -> s.getWriter()
                                                       .equals(loginUser))
                                         .orElseThrow(NoSuchElementException::new);
         return question.update(updatedQuestion);

--- a/src/main/java/codesquad/service/QnaService.java
+++ b/src/main/java/codesquad/service/QnaService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Resource;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service("qnaService")
@@ -38,12 +39,21 @@ public class QnaService {
     @Transactional
     public Question update(User loginUser, long id, Question updatedQuestion) {
         // TODO 수정 기능 구현
-        return null;
+        Question question = findById(id).filter(s -> s.getWriter()
+                                                      .equals(loginUser))
+                                        .orElseThrow(NoSuchElementException::new);
+        return question.update(updatedQuestion);
     }
 
     @Transactional
     public void deleteQuestion(User loginUser, long questionId) throws CannotDeleteException {
         // TODO 삭제 기능 구현
+        Question question = questionRepository.findById(questionId)
+                                              .filter(s -> s.getWriter()
+                                                            .equals(loginUser))
+                                              .orElseThrow(NoSuchElementException::new);
+        question.setDeleted(true);
+        questionRepository.delete(question);
     }
 
     public Iterable<Question> findAll() {
@@ -53,6 +63,7 @@ public class QnaService {
     public List<Question> findAll(Pageable pageable) {
         return questionRepository.findAll(pageable).getContent();
     }
+
 
     public Answer addAnswer(User loginUser, long questionId, String contents) {
         // TODO 답변 추가 기능 구현

--- a/src/main/java/codesquad/web/HomeController.java
+++ b/src/main/java/codesquad/web/HomeController.java
@@ -1,13 +1,22 @@
 package codesquad.web;
 
+import codesquad.service.QnaService;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class HomeController {
+
+    private final QnaService qnaService;
+
+    public HomeController(QnaService qnaService) {
+        this.qnaService = qnaService;
+    }
+
     @GetMapping("/")
     public String home(Model model) {
+        model.addAttribute("questions", qnaService.findAll());
         return "home";
     }
 }

--- a/src/main/java/codesquad/web/QuestionController.java
+++ b/src/main/java/codesquad/web/QuestionController.java
@@ -7,55 +7,62 @@ import codesquad.security.LoginUser;
 import codesquad.service.QnaService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.NoSuchElementException;
 
 @Controller
 @RequestMapping("/questions")
 public class QuestionController {
     public static final Logger log = LoggerFactory.getLogger(QuestionController.class);
 
-    @Autowired
-    private QnaService qnaService;
+    private final QnaService qnaService;
+
+    public QuestionController(QnaService qnaService) {
+        this.qnaService = qnaService;
+    }
 
     @GetMapping("/form")
     public String form(@LoginUser User loginUser) {
-        return "/qna/form";
+        log.debug("form() loginUser ={}", loginUser);
+        return "qna/form";
     }
 
     @PostMapping("")
     public String create(@LoginUser User loginUser, Question question) {
+        log.debug("create() loginUser ={}", loginUser);
+        log.debug("create() question ={}", question);
         qnaService.create(loginUser, question);
         return "redirect:/users";
     }
 
     @DeleteMapping("/{id}")
     public String remove(@PathVariable Long id, @LoginUser User loginUser) throws CannotDeleteException {
+        log.debug("remove() loginUser ={}", loginUser);
         qnaService.deleteQuestion(loginUser, id);
         return "redirect:/";
     }
 
     @GetMapping("/{id}")
-    public String show(@PathVariable Long id, @LoginUser User loginUSer, Model model) {
-        Question question = qnaService.findById(id)
-                                      .orElseThrow(NoSuchElementException::new);
-
+    public String show(@PathVariable Long id, @LoginUser User loginUser, Model model) {
+        log.debug("show() loginUser ={}", loginUser);
+        Question question = qnaService.findById(id);
         model.addAttribute("question", question);
         return "qna/show";
     }
 
     @GetMapping("/updateForm")
     public String updateForm(@LoginUser User loginUser) {
+        log.debug("updateForm() loginUser ={}", loginUser);
         return "qna/updateForm";
     }
 
 
     @PutMapping("/{id}")
     public String update(@PathVariable Long id, @LoginUser User loginUser, Question question) {
+        log.debug("update() loginUser ={}", loginUser);
+        log.debug("update() question ={}", question);
         qnaService.update(loginUser, id, question);
         return "redirect:/";
     }

--- a/src/main/java/codesquad/web/QuestionController.java
+++ b/src/main/java/codesquad/web/QuestionController.java
@@ -25,28 +25,28 @@ public class QuestionController {
 
     @GetMapping("/form")
     public String form(@LoginUser User loginUser) {
-        log.debug("form() loginUser ={}", loginUser);
+        log.debug("QuestionController form() loginUser ={}", loginUser);
         return "qna/form";
     }
 
     @PostMapping("")
     public String create(@LoginUser User loginUser, Question question) {
-        log.debug("create() loginUser ={}", loginUser);
-        log.debug("create() question ={}", question);
+        log.debug("QuestionController create() loginUser ={}", loginUser);
+        log.debug("QuestionController create() question ={}", question);
         qnaService.create(loginUser, question);
         return "redirect:/users";
     }
 
     @DeleteMapping("/{id}")
     public String remove(@PathVariable Long id, @LoginUser User loginUser) throws CannotDeleteException {
-        log.debug("remove() loginUser ={}", loginUser);
+        log.debug("QuestionController remove() loginUser ={}", loginUser);
         qnaService.deleteQuestion(loginUser, id);
         return "redirect:/";
     }
 
     @GetMapping("/{id}")
     public String show(@PathVariable Long id, @LoginUser User loginUser, Model model) {
-        log.debug("show() loginUser ={}", loginUser);
+        log.debug("QuestionController show() loginUser ={}", loginUser);
         Question question = qnaService.findById(id);
         model.addAttribute("question", question);
         return "qna/show";
@@ -54,15 +54,15 @@ public class QuestionController {
 
     @GetMapping("/updateForm")
     public String updateForm(@LoginUser User loginUser) {
-        log.debug("updateForm() loginUser ={}", loginUser);
+        log.debug("QuestionController updateForm() loginUser ={}", loginUser);
         return "qna/updateForm";
     }
 
 
     @PutMapping("/{id}")
     public String update(@PathVariable Long id, @LoginUser User loginUser, Question question) {
-        log.debug("update() loginUser ={}", loginUser);
-        log.debug("update() question ={}", question);
+        log.debug("QuestionController update() loginUser ={}", loginUser);
+        log.debug("QuestionController update() question ={}", question);
         qnaService.update(loginUser, id, question);
         return "redirect:/";
     }

--- a/src/main/java/codesquad/web/QuestionController.java
+++ b/src/main/java/codesquad/web/QuestionController.java
@@ -1,0 +1,62 @@
+package codesquad.web;
+
+import codesquad.CannotDeleteException;
+import codesquad.domain.Question;
+import codesquad.domain.User;
+import codesquad.security.LoginUser;
+import codesquad.service.QnaService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.NoSuchElementException;
+
+@Controller
+@RequestMapping("/questions")
+public class QuestionController {
+    public static final Logger log = LoggerFactory.getLogger(QuestionController.class);
+
+    @Autowired
+    private QnaService qnaService;
+
+    @GetMapping("/form")
+    public String form(@LoginUser User loginUser) {
+        return "/qna/form";
+    }
+
+    @PostMapping("")
+    public String create(@LoginUser User loginUser, Question question) {
+        qnaService.create(loginUser, question);
+        return "redirect:/users";
+    }
+
+    @DeleteMapping("/{id}")
+    public String remove(@PathVariable Long id, @LoginUser User loginUser) throws CannotDeleteException {
+        qnaService.deleteQuestion(loginUser, id);
+        return "redirect:/";
+    }
+
+    @GetMapping("/{id}")
+    public String show(@PathVariable Long id, @LoginUser User loginUSer, Model model) {
+        Question question = qnaService.findById(id)
+                                      .orElseThrow(NoSuchElementException::new);
+
+        model.addAttribute("question", question);
+        return "qna/show";
+    }
+
+    @GetMapping("/updateForm")
+    public String updateForm(@LoginUser User loginUser) {
+        return "qna/updateForm";
+    }
+
+
+    @PutMapping("/{id}")
+    public String update(@PathVariable Long id, @LoginUser User loginUser, Question question) {
+        qnaService.update(loginUser, id, question);
+        return "redirect:/";
+    }
+}

--- a/src/main/java/codesquad/web/UserController.java
+++ b/src/main/java/codesquad/web/UserController.java
@@ -7,6 +7,7 @@ import codesquad.security.LoginUser;
 import codesquad.service.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -42,11 +43,15 @@ public class UserController {
         return "/user/list";
     }
 
+    @Autowired
+    private HttpSession httpSession;
+
     @PostMapping("/login")
-    public String login(String userId, String password, HttpSession httpSession) {
+    public String login(String userId, String password) {
         try {
             User user = userService.login(userId, password);
             httpSession.setAttribute(HttpSessionUtils.USER_SESSION_KEY, user);
+            log.debug("컨트롤러 세션 값 =" + httpSession.getAttribute(HttpSessionUtils.USER_SESSION_KEY));
         } catch (UnAuthenticationException unAuthenticationException) {
             return "user/login_failed";
         }

--- a/src/test/java/codesquad/service/QnaServiceTest.java
+++ b/src/test/java/codesquad/service/QnaServiceTest.java
@@ -18,7 +18,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/codesquad/service/QnaServiceTest.java
+++ b/src/test/java/codesquad/service/QnaServiceTest.java
@@ -1,0 +1,148 @@
+package codesquad.service;
+
+import codesquad.CannotDeleteException;
+import codesquad.domain.Question;
+import codesquad.domain.QuestionRepository;
+import codesquad.domain.User;
+import codesquad.domain.UserTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QnaServiceTest {
+    public static final Logger log = LoggerFactory.getLogger(QnaServiceTest.class);
+
+    @Mock
+    private QuestionRepository questionRepository;
+
+    @InjectMocks
+    private QnaService qnaService;
+
+    private User authorizedUser;
+    private User unAuthorizedUser;
+
+    @Before
+    public void setUp() {
+        authorizedUser = UserTest.JAVAJIGI;
+        unAuthorizedUser = UserTest.SANJIGI;
+
+    }
+
+    public Question makeDefaultQuestion() {
+        Question defaultQuestion = new Question("title1", "contents1");
+        defaultQuestion.setId(1L);
+        defaultQuestion.setWriter(authorizedUser);
+
+        return defaultQuestion;
+    }
+
+    @Test
+    public void 질문을_저장할_때_작성자_이름과_질문이_잘_저장되는지_테스트() {
+        //given
+        Question beforeSavedQuestion = makeDefaultQuestion();
+        when(questionRepository.save(beforeSavedQuestion)).thenReturn(beforeSavedQuestion);
+
+        //when
+        Question savedQuestion = qnaService.create(authorizedUser, beforeSavedQuestion);
+        log.debug("beforeSavedQuestion ={}", beforeSavedQuestion);
+        log.debug("savedQuestion ={}", savedQuestion);
+
+        //then
+        assertThat(savedQuestion.getWriter()).isEqualTo(authorizedUser);
+        assertThat(beforeSavedQuestion).isEqualTo(savedQuestion);
+    }
+
+    @Test
+    public void 질문ID로_질문을_조회할_떄_질문이_잘_반환되는지_테스트() {
+        //given
+        Question question = makeDefaultQuestion();
+
+        log.debug("afterSavedQuestion Id ={}", question.getId());
+        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
+
+        //when
+        Question afterFindByIdQuestion = qnaService.findById(question.getId());
+
+        //then
+        assertThat(question).isEqualTo(afterFindByIdQuestion);
+    }
+
+    @Test
+    public void 작성자와_로그인한_사용자가_일치할_때_질문이_잘_삭제되는지_테스트() throws CannotDeleteException {
+        //given
+        Question question = makeDefaultQuestion();
+
+        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
+
+        //when
+        qnaService.deleteQuestion(authorizedUser, question.getId());
+        log.debug("question isDeleted ={}", question.isDeleted());
+
+        //then
+        assertThat(question.isDeleted()).isEqualTo(true);
+    }
+
+    @Test
+    public void 작성자와_로그인한_사용자가_일치하지_않을_때_질문이_삭제되지_않는지_테스트() throws CannotDeleteException {
+        //given
+        Question question = makeDefaultQuestion();
+
+        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
+
+        //when
+        NoSuchElementException noSuchElementException = assertThrows(NoSuchElementException.class, () -> qnaService.deleteQuestion(unAuthorizedUser, question.getId()));
+
+        //then
+        log.debug("question isDeleted ={}", question.isDeleted());
+        assertThat(question.isDeleted()).isEqualTo(false);
+        assertThat(noSuchElementException).isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    public void 작성자와_로그인한_사용자가_일치할_때_질문이_잘_수정되는지_테스트() {
+        //given
+        Question question = makeDefaultQuestion();
+        Question newQuestion = new Question("title2", "content2");
+
+        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
+
+        //when
+        Question afterUpdateQuestion = qnaService.update(authorizedUser, question.getId(), newQuestion);
+
+        log.debug("afterUpdateQuestion title ={}", afterUpdateQuestion.getTitle());
+        log.debug("afterUpdateQuestion contents ={}", afterUpdateQuestion.getContents());
+        log.debug("afterUpdateQuestion writer ={}", afterUpdateQuestion.getWriter());
+
+        //then
+        assertThat(question).isEqualTo(afterUpdateQuestion);
+        assertThat(question.getWriter()).isEqualTo(afterUpdateQuestion.getWriter());
+    }
+
+    @Test
+    public void 작성자와_로그인한_사용자가_일치하지_않을_때_질문이_수정되지_않는지_테스트() {
+        //given
+        Question question = makeDefaultQuestion();
+        Question newQuestion = new Question("title2", "contents2");
+
+        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
+
+        //when
+        NoSuchElementException noSuchElementException = assertThrows(NoSuchElementException.class, () -> qnaService.update(unAuthorizedUser, question.getId(), newQuestion));
+
+        //then
+        assertThat(noSuchElementException).isInstanceOf(NoSuchElementException.class);
+    }
+}

--- a/src/test/java/codesquad/web/LoginAcceptanceTest.java
+++ b/src/test/java/codesquad/web/LoginAcceptanceTest.java
@@ -3,69 +3,67 @@ package codesquad.web;
 import codesquad.HtmlFormDataBuilder;
 import codesquad.domain.User;
 import codesquad.security.HttpSessionUtils;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.*;
 import org.junit.Test;
-import org.springframework.mock.web.MockHttpSession;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.MultiValueMap;
 import support.test.AcceptanceTest;
 
 import static org.assertj.core.api.Assertions.*;
 
+@Transactional
 public class LoginAcceptanceTest extends AcceptanceTest {
     public static final Logger log =  LoggerFactory.getLogger(LoginAcceptanceTest.class);
+
+    private static String userId;
+    private static String password;
+    private static String name;
+    private static String email;
+
+    @BeforeClass
+    public static void init() {
+        userId = "javajigi";
+        password = "test";
+        name = "자바지기";
+        email = "javajigi@slipp.net";
+    }
 
     @Test
     public void login_success() throws Exception {
         //given
-        String userId = "user1";
-        String password = "password1";
-        String name = "name1";
-        String email = "email1@gmail.com";
-        User user = new User(userId, password, name, email);
-        save(user);
-
         HtmlFormDataBuilder htmlFormDataBuilder = HtmlFormDataBuilder.urlEncodeForm();
         htmlFormDataBuilder.addParameter("userId", userId);
         htmlFormDataBuilder.addParameter("password", password);
-        htmlFormDataBuilder.addParameter("name", name);
-        htmlFormDataBuilder.addParameter("email", email);
-        HttpEntity<MultiValueMap<String, Object>> request = htmlFormDataBuilder.build();
-        MockHttpSession session = new MockHttpSession();
+        HttpEntity<MultiValueMap<String, Object>> request = htmlFormDataBuilder.build();;
 
         // when
-        ResponseEntity<String> response = basicAuthTemplate(user).postForEntity("/users/login", request, String.class);
-        session.setAttribute(HttpSessionUtils.USER_SESSION_KEY, findByUserId(userId));
-
+        ResponseEntity<String> response = basicAuthTemplate().postForEntity("/users/login", request, String.class);
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
-        assertThat(session.getAttribute(HttpSessionUtils.USER_SESSION_KEY)).isEqualTo(user);
+        assertThat(response.getHeaders()
+                           .get("Set-Cookie")
+                           .get(0)).isNotEmpty();
     }
 
     @Test
     public void login_failed() throws Exception {
         // given
-        String userId = "user1";
-        String password = "password1";
-        String name = "name1";
-        String email = "email1@gmail.com";
-        User user = new User(userId, password, name, email);
-        save(user);
-
         HtmlFormDataBuilder htmlFormDataBuilder = HtmlFormDataBuilder.urlEncodeForm();
-        htmlFormDataBuilder.addParameter("userId", "user2");
+        htmlFormDataBuilder.addParameter("userId", "wrongId");
         htmlFormDataBuilder.addParameter("password", password);
-        htmlFormDataBuilder.addParameter("name", name);
-        htmlFormDataBuilder.addParameter("email", email);
         HttpEntity<MultiValueMap<String, Object>> request = htmlFormDataBuilder.build();
-        MockHttpSession session = new MockHttpSession();
 
         // when
-        ResponseEntity<String> response = basicAuthTemplate(user).postForEntity("/users/login", request, String.class);
-        session.setAttribute(HttpSessionUtils.USER_SESSION_KEY, user);
+        ResponseEntity<String> response = template().postForEntity("/users/login", request, String.class);
+        log.debug("response의 헤더 = {}", response.getHeaders());
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders()
+                           .get("Set-Cookie")).isNull();
     }
 }

--- a/src/test/java/codesquad/web/LoginAcceptanceTest.java
+++ b/src/test/java/codesquad/web/LoginAcceptanceTest.java
@@ -1,9 +1,6 @@
 package codesquad.web;
 
 import codesquad.HtmlFormDataBuilder;
-import codesquad.domain.User;
-import codesquad.security.HttpSessionUtils;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/test/java/codesquad/web/QuestionAcceptanceTest.java
+++ b/src/test/java/codesquad/web/QuestionAcceptanceTest.java
@@ -3,6 +3,7 @@ package codesquad.web;
 import codesquad.HtmlFormDataBuilder;
 import codesquad.domain.Question;
 import codesquad.domain.QuestionRepository;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.DisplayName;
@@ -15,7 +16,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
 import support.test.AcceptanceTest;
-
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,6 +32,11 @@ public class QuestionAcceptanceTest extends AcceptanceTest {
         Question question = new Question("before() Title", "before() Contents");
         question.setWriter(defaultUser());
         this.question = questionRepository.save(question);
+    }
+
+    @After
+    public void after() {
+        questionRepository.deleteAll();
     }
 
     @Test
@@ -108,7 +113,6 @@ public class QuestionAcceptanceTest extends AcceptanceTest {
         HttpEntity<MultiValueMap<String, Object>> request = htmlFormDataBuilder.build();
         //when
         ResponseEntity<String> response = basicAuthTemplate().exchange("/questions/1", HttpMethod.DELETE, request, String.class);
-
         //then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
         assertThat(questionRepository.findAll()
@@ -183,9 +187,7 @@ public class QuestionAcceptanceTest extends AcceptanceTest {
                                                                      .addParameter("contents", "수정된 내용");
         HttpEntity<MultiValueMap<String, Object>> request = htmlFormDataBuilder.build();
         //when
-
         ResponseEntity<String> response = basicAuthTemplate().exchange("/questions/" + id, HttpMethod.PUT, request, String.class);
-
         //then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
     }

--- a/src/test/java/codesquad/web/QuestionAcceptanceTest.java
+++ b/src/test/java/codesquad/web/QuestionAcceptanceTest.java
@@ -1,0 +1,192 @@
+package codesquad.web;
+
+import codesquad.HtmlFormDataBuilder;
+import codesquad.domain.Question;
+import codesquad.domain.QuestionRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
+import support.test.AcceptanceTest;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QuestionAcceptanceTest extends AcceptanceTest {
+    public static final Logger log = LoggerFactory.getLogger(QuestionAcceptanceTest.class);
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    private Question question;
+
+    @Before
+    public void before() {
+        Question question = new Question("before() Title", "before() Contents");
+        question.setWriter(defaultUser());
+        this.question = questionRepository.save(question);
+    }
+
+    @Test
+    @DisplayName("로그인 하지 않고 질문 작성 폼 보여주기 요청이 들어왔을때 보여주지 않는지 테스트")
+    public void createForm_unauthorized() {
+        //given
+        //when
+        ResponseEntity<String> response = template().getForEntity("/questions/form", String.class);
+        //then
+        assertThat(response.getStatusCode())
+                .isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("로그인 하고 질문 작성 폼 보여주기 요청이 들어왔을때 잘 보여주는지 테스트")
+    public void createForm_authorized() {
+        //given
+        //when
+        ResponseEntity<String> response = basicAuthTemplate().getForEntity("/questions/form", String.class);
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    @DisplayName("로그인 하지 않았을 때 질문이 생성되지 않는지를 테스트")
+    public void create_unauthorized() {
+        //given
+        HtmlFormDataBuilder htmlFormDataBuilder = HtmlFormDataBuilder.urlEncodeForm();
+        htmlFormDataBuilder.addParameter("title", "title1");
+        htmlFormDataBuilder.addParameter("contents", "contents1");
+        HttpEntity<MultiValueMap<String, Object>> request = htmlFormDataBuilder.build();
+        //when
+        ResponseEntity<String> response = template().postForEntity("/questions", request, String.class);
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("로그인 했을 때 질문이 잘 생성되는지 테스트")
+    public void create_authorized() {
+        //given
+        int size = questionRepository.findAll()
+                                     .size();
+        HtmlFormDataBuilder htmlFormDataBuilder = HtmlFormDataBuilder.urlEncodeForm();
+        htmlFormDataBuilder.addParameter("title", "title1");
+        htmlFormDataBuilder.addParameter("contents", "contents1");
+        HttpEntity<MultiValueMap<String, Object>> request = htmlFormDataBuilder.build();
+        //when
+        ResponseEntity<String> response = basicAuthTemplate().postForEntity("/questions", request, String.class);
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
+        assertThat(questionRepository.findAll().size()).isEqualTo(size+1);
+    }
+
+    @Test
+    @DisplayName("로그인 하지 않고 질문을 삭제하려고 했을 때 삭제가 안되는지 테스트")
+    public void delete_unauthorized() {
+        //given
+        HtmlFormDataBuilder htmlFormDataBuilder = HtmlFormDataBuilder.urlEncodeForm();
+        HttpEntity<MultiValueMap<String, Object>> request = htmlFormDataBuilder.build();
+        //when
+        ResponseEntity<String> response = template().exchange("/questions/1", HttpMethod.DELETE, request, String.class);
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("로그인 하고 질문을 삭제하려고 했을 때 잘 삭제 되는지 테스트")
+    public void delete_authorized() {
+        //given
+        int size = questionRepository.findAll()
+                                     .size();
+        HtmlFormDataBuilder htmlFormDataBuilder = HtmlFormDataBuilder.urlEncodeForm();
+        HttpEntity<MultiValueMap<String, Object>> request = htmlFormDataBuilder.build();
+        //when
+        ResponseEntity<String> response = basicAuthTemplate().exchange("/questions/1", HttpMethod.DELETE, request, String.class);
+
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
+        assertThat(questionRepository.findAll()
+                                     .size()).isEqualTo(size - 1);
+    }
+
+    @Test
+    @DisplayName("로그인 하지 않고 작성된 질문을 읽으려고 했을 때 읽어지지 않는지 테스트")
+    public void read_unauthorized() {
+        //given
+        Long id = 1L;
+        //when
+        ResponseEntity<String> response = template().getForEntity("/questions/" + id, String.class);
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("로그인 하고 작성된 질문을 읽으려고 했을 때 잘 읽어지는지 테스트")
+    public void read_authorized() {
+        //given
+        //when
+        ResponseEntity<String> response = basicAuthTemplate().getForEntity("/questions/" + this.question.getId(), String.class);
+        //then
+        log.debug("response.getBody() = {}", response.getBody());
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains(this.question.getContents());
+    }
+
+    @Test
+    @DisplayName("로그인 하지 않고 수정 폼을 열려고 할 때 열리지 않는지 테스트")
+    public void updateForm_unauthorized() {
+        //given
+        //when
+        ResponseEntity<String> response = template().getForEntity("/questions/updateForm", String.class);
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("로그인 하고 수정 폼을 열려고 했을 때 잘 열리는지 테스트")
+    public void updateForm_authorized() {
+        //given
+        //when
+        ResponseEntity<String> response = basicAuthTemplate().getForEntity("/questions/updateForm", String.class);
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    @DisplayName("로그인 하지 않고 수정 요청을 보냈을 때 수정이 되지 않는지 테스트")
+    public void update_unauthorized() {
+        //given
+        Long id = this.question.getId();
+        HtmlFormDataBuilder htmlFormDataBuilder = HtmlFormDataBuilder.urlEncodeForm()
+                                                                     .addParameter("title", "수정할 제목")
+                                                                     .addParameter("contents", "수정된 내용");
+        HttpEntity<MultiValueMap<String, Object>> request = htmlFormDataBuilder.build();
+        //when
+        ResponseEntity<String> response = template().exchange("/questions/" + id, HttpMethod.PUT, request, String.class);
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("로그인 하고 수정 요청을 보냈을 때 수정이 잘 되는지 테스트")
+    public void update_authorized() {
+        //given
+        Long id = this.question.getId();
+        HtmlFormDataBuilder htmlFormDataBuilder = HtmlFormDataBuilder.urlEncodeForm()
+                                                                     .addParameter("title", "수정할 제목")
+                                                                     .addParameter("contents", "수정된 내용");
+        HttpEntity<MultiValueMap<String, Object>> request = htmlFormDataBuilder.build();
+        //when
+
+        ResponseEntity<String> response = basicAuthTemplate().exchange("/questions/" + id, HttpMethod.PUT, request, String.class);
+
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
+    }
+}

--- a/src/test/java/codesquad/web/QuestionControllerTest.java
+++ b/src/test/java/codesquad/web/QuestionControllerTest.java
@@ -17,7 +17,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = QuestionControllerTest.class)
 @RunWith(MockitoJUnitRunner.class)
 public class QuestionControllerTest {
     @InjectMocks

--- a/src/test/java/codesquad/web/QuestionControllerTest.java
+++ b/src/test/java/codesquad/web/QuestionControllerTest.java
@@ -1,0 +1,105 @@
+package codesquad.web;
+
+import codesquad.domain.User;
+import codesquad.domain.UserTest;
+import codesquad.service.QnaService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = QuestionControllerTest.class)
+@RunWith(MockitoJUnitRunner.class)
+public class QuestionControllerTest {
+    @InjectMocks
+    QuestionController questionController;
+
+    @Mock
+    QnaService qnaService;
+
+    private User user;
+    private MockMvc mockMvc;
+
+    @Before
+    public void setUp() {
+        user = UserTest.JAVAJIGI;
+        mockMvc = MockMvcBuilders.standaloneSetup(questionController)
+                                 .build();
+    }
+
+    @Test
+    public void form() throws Exception {
+        mockMvc.perform(get("/questions/form")
+                       .param("userId", user.getUserId())
+                       .param("password", user.getPassword())
+                       .param("name", user.getName())
+                       .param("email", user.getEmail()))
+               .andExpect(status().isOk())
+               .andExpect(forwardedUrl("qna/form"));
+    }
+
+    @Test
+    public void create() throws Exception {
+        mockMvc.perform(post("/questions")
+                       .param("userId", user.getUserId())
+                       .param("password", user.getPassword())
+                       .param("name", user.getName())
+                       .param("email", user.getEmail())
+                       .param("title", "title1")
+                       .param("contents", "contents1"))
+               .andExpect(status().isFound());
+    }
+
+    @Test
+    public void remove() throws Exception {
+        mockMvc.perform(delete("/questions/{id}", 1)
+                       .param("userId", user.getUserId())
+                       .param("password", user.getPassword())
+                       .param("name", user.getName())
+                       .param("email", user.getEmail()))
+               .andExpect(status().isFound());
+    }
+
+    @Test
+    public void show() throws Exception {
+        mockMvc.perform(get("/questions/{id}", 1)
+                       .param("userId", user.getUserId())
+                       .param("password", user.getPassword())
+                       .param("name", user.getName())
+                       .param("email", user.getEmail()))
+               .andExpect(status().isOk())
+               .andExpect(forwardedUrl("qna/show"));
+    }
+
+    @Test
+    public void updateForm() throws Exception {
+        mockMvc.perform(get("/questions/updateForm")
+                       .param("userId", user.getUserId())
+                       .param("password", user.getPassword())
+                       .param("name", user.getName())
+                       .param("email", user.getEmail()))
+               .andExpect(status().isOk())
+               .andExpect(forwardedUrl("qna/updateForm"));
+    }
+
+    @Test
+    public void update() throws Exception {
+        mockMvc.perform(put("/questions/{id}", 1)
+                       .param("userId", user.getUserId())
+                       .param("password", user.getPassword())
+                       .param("name", user.getName())
+                       .param("email", user.getEmail())
+                       .param("title", "title1")
+                       .param("contents", "contents1"))
+               .andExpect(status().isFound());
+    }
+}


### PR DESCRIPTION
### 테스트의 독립적인 성공을 보장하기 위한 시도

CRUD 기능을 테스트 하다 보면, 어떤 테스트 메서드에서는 새로운 데이터가 추가되어지고, 어떤 메서드에서는 기존의 데이터가 삭제가 되기도 하였습니다.

이번에 테스트 코드를 작성하면서, `Question`의 `id` 값을 이용해서 DB의 데이터를 찾아오고, 데이터를 업데이트하는 로직이 있었는데, 이 과정에서 기존에 있던 id의 값이 1인 데이터베이스의 데이터를 `update()` 하는 과정에서, `delete()` 메서드가 선행되면서 업데이트 하고자 하는 데이터가 삭제 되어버려 에러가 발생하는 문제가 있었습니다..

이를 해결하기 위해서 `@Transactional`을 이용해서 데이터베이스에 삭제 메서드가 반영이 되지 않도록 하고자 하였지만, `id` 값은 `@Transactional`로 데이터 롤백이 보장되지 않음을 알게 되었습니다.

이를 해결하기 위해서 아래와 같은 방법을 시도해 보았습니다.

1. **`@DirtiesContext`**

```java
@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
```

- 테스트 코드 실행할때마다 스프링 컨테이너를 올렸다 내렸다가 해줌.
- 다른 테스트의 영향을 받지 않고, 독립적으로 테스트를 수행 할 수 있게 해준다.

위 어노테이션을 클래스 레벨에 선언 해줌으로써 각 테스트가 독립적으로 성공할 수 있었습니다. 그러나 실행보면 알 수 있었듯이 스프링 컨테이너를 계속해서 올렸다 내리기 때문에 수행 속도가 매우 느렸습니다.

이 방법이 좋지 않다고 생각하여, 현재는 다음과 같이 구현해 놓은 상태입니다.

2. **`@Before`**

```java
private Question question;

@Before
public void before() {
		Question question = new Question("before() Title", "before() Contents");
    question.setWriter(defaultUser());
    this.question = questionRepository.save(question);
}

...
  
@Test
@DisplayName("로그인 하고 수정 요청을 보냈을 때 수정이 잘 되는지 테스트")
public void update_authorized() {
    //given
    Long id = this.question.getId();
    HtmlFormDataBuilder htmlFormDataBuilder = HtmlFormDataBuilder.urlEncodeForm()
      												.addParameter("title", "수정할 제목")
      												.addParameter("contents", "수정된 내용");
    HttpEntity<MultiValueMap<String, Object>> request = htmlFormDataBuilder.build();
    //when
    ResponseEntity<String> response = basicAuthTemplate().exchange("/questions/" + id, HttpMethod.PUT, request, String.class);
    //then
    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
}
```

이 방법 역시 좋지 않은 방법이라고 생각이 되지만 , 매 테스트 수행시 새로운 데이터 `@Before` 어노테이션을 이용해 데이터베이스에 추가해주고, 막 생성된 시점의 `id` 값을 `update()` 메서드에서 호출해 사용하도록 하여 다른 테스트 메서드에 의한 데이터베이스의 간섭이 일어나지 않도록 하였습니다.

사실 데이터베이스 간섭이 일어나지 않도록 한 것이 아니라, 일어날 수 없도록 만든 것이라는 생각이 듭니다. 

**[질문]**
동일한 `id`값을 이용해서 여러 케이스의 테스트 코드를 작성할 때, 각 테스트의 독립적인 성공을 보장할 수 있는 더 나은 방법이 있는지 궁금합니다...!

### ATDD 수행 순서

1. 기존에 사용하였던 `TestRestTemplate`를 사용해서 `GET`, `POST`, `DELETE` , `PUT` 등의 요청을 작성한다.
2. 컨트롤러에 매핑하고자하는 메서드 어노테이션과, url을 선언한다.
3. 해당 기능을 요청하는데 필요로하는 파라미터가 있다면, `HtmlFormDataBuilder`를 이용해서 `//given` 위치에 작성해준다.
4. `HttpStatus`가 예측 값으로 테스트가 되는지 확인한 후, 구현하고자 하는 테스트를 작성한다.
5. Controller, Service 순으로 로직을 구현하고, 테스트를 진행한다.

잘 정리해보고 싶었는데, 말이 깔끔하게 정리가 잘 되지 않네요...! 대략적으로는 위와 같은 흐름으로 ATDD를 진행하였는데, ATDD가 추구하는 바에 맞게 구현한 것인지 궁금합니다.

