### PR TITLE
[4단계] 구현 완료했습니다. 리뷰 부탁드립니다

### DIFF
--- a/src/main/java/codesquad/domain/Answer.java
+++ b/src/main/java/codesquad/domain/Answer.java
@@ -6,6 +6,7 @@ import support.domain.UrlGeneratable;
 
 import javax.persistence.*;
 import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
 
 @Entity
 public class Answer extends AbstractEntity implements UrlGeneratable {
@@ -75,11 +76,12 @@ public class Answer extends AbstractEntity implements UrlGeneratable {
         this.contents = updatedContents;
     }
 
-    public void delete(User loginUser) {
+    public DeleteHistory delete(User loginUser) {
         if (!isOwner(loginUser)) {
             throw new UnAuthorizedException();
         }
         this.deleted = true;
+        return new DeleteHistory(ContentType.ANSWER, this.getId(), loginUser, LocalDateTime.now());
     }
 
     @Override

--- a/src/main/java/codesquad/service/DeleteHistoryService.java
+++ b/src/main/java/codesquad/service/DeleteHistoryService.java
@@ -20,4 +20,9 @@ public class DeleteHistoryService {
             deleteHistoryRepository.save(deleteHistory);
         }
     }
+
+    @Transactional
+    public void save(DeleteHistory deleteHistory) {
+        deleteHistoryRepository.save(deleteHistory);
+    }
 }

--- a/src/main/java/codesquad/service/QnaService.java
+++ b/src/main/java/codesquad/service/QnaService.java
@@ -55,14 +55,9 @@ public class QnaService {
 
     @Transactional
     public Question deleteQuestion(User loginUser, long questionId) throws CannotDeleteException {
-        // TODO 삭제 기능 구현
         Question savedQuestion = findById(questionId);
 
-        if (!savedQuestion.isOwner(loginUser)) {
-            throw new CannotDeleteException("삭제 권한이 없습니다.");
-        }
-
-        savedQuestion.delete();
+        deleteHistoryService.saveAll(savedQuestion.delete(loginUser));
         return questionRepository.save(savedQuestion);
     }
 
@@ -92,7 +87,7 @@ public class QnaService {
     @Transactional
     public Answer deleteAnswer(User loginUser, long id) {
         Answer answer = findAnswerById(id);
-        answer.delete(loginUser);
+        deleteHistoryService.save(answer.delete(loginUser));
         return answerRepository.save(answer);
     }
 }

--- a/src/test/java/codesquad/domain/QuestionTest.java
+++ b/src/test/java/codesquad/domain/QuestionTest.java
@@ -1,5 +1,7 @@
 package codesquad.domain;
 
+import codesquad.CannotDeleteException;
+import codesquad.CannotDeleteException;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,12 +41,45 @@ public class QuestionTest {
     }
 
     @Test
-    public void delete() {
+    public void delete() throws CannotDeleteException {
         User loginUser = UserTest.JAVAJIGI;
         Question question = newQuestion(1L, loginUser);
 
-        question.delete();
+        question.delete(loginUser);
 
         assertThat(question.isDeleted()).isTrue();
+    }
+
+    @Test(expected = CannotDeleteException.class)
+    public void delete_fail_when_loginUser_mismatch_writer() throws CannotDeleteException {
+        User loginUser = UserTest.JAVAJIGI;
+        User otherUser = UserTest.SANJIGI;
+        Question question = newQuestion(1L, loginUser);
+
+        question.delete(otherUser);
+    }
+
+    @Test
+    public void delete_success_when_loginUser_is_writer_correspond_to_answers() throws CannotDeleteException {
+        User loginUser = UserTest.JAVAJIGI;
+        Question question = newQuestion(1L, loginUser);
+        question.addAnswer(new Answer(loginUser, "하이"));
+
+        assertThat(question.hasSameWriterWithAnswers()).isTrue();
+
+        question.delete(loginUser);
+        assertThat(question.isDeleted()).isTrue();
+    }
+
+    @Test(expected = CannotDeleteException.class)
+    public void delete_fail_when_loginUser_is_not_writer_correspond_to_answers() throws CannotDeleteException {
+        User loginUser = UserTest.JAVAJIGI;
+        User otherUser = UserTest.SANJIGI;
+        Question question = newQuestion(1L, loginUser);
+        question.addAnswer(new Answer(otherUser, "하이"));
+
+        assertThat(question.hasSameWriterWithAnswers()).isFalse();
+
+        question.delete(loginUser);
     }
 }

--- a/src/test/java/codesquad/web/ApiQuestionAcceptanceTest.java
+++ b/src/test/java/codesquad/web/ApiQuestionAcceptanceTest.java
@@ -79,7 +79,7 @@ public class ApiQuestionAcceptanceTest extends AcceptanceTest {
         template().delete(location);
 
         Question dbQuestion = getResource(location, Question.class);
-        assertT가hat(dbQuestion.isDeleted()).isFalse();
+        assertThat(dbQuestion.isDeleted()).isFalse();
     }
 
     @Test

--- a/src/test/java/codesquad/web/ApiQuestionAcceptanceTest.java
+++ b/src/test/java/codesquad/web/ApiQuestionAcceptanceTest.java
@@ -19,11 +19,6 @@ public class ApiQuestionAcceptanceTest extends AcceptanceTest {
 
     private Question newQuestion;
 
-    @Before
-    public void setUp() throws Exception {
-        newQuestion = defaultQuestion();
-    }
-
     @Test
     public void create() {
         Question newQuestion = defaultQuestion();
@@ -68,13 +63,23 @@ public class ApiQuestionAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    public void delete() {
+    public void delete_success() {
         String location = createResource(DEFAULT_QUESTION_URL, newQuestion);
 
         basicAuthTemplate().delete(location);
 
         Question dbQuestion = getResource(location, Question.class);
         assertThat(dbQuestion.isDeleted()).isTrue();
+    }
+
+    @Test
+    public void delete_fail() {
+        String location = createResource(DEFAULT_QUESTION_URL, newQuestion);
+
+        template().delete(location);
+
+        Question dbQuestion = getResource(location, Question.class);
+        assertT가hat(dbQuestion.isDeleted()).isFalse();
     }
 
     @Test

--- a/src/test/java/codesquad/web/QuestionAcceptanceTest.java
+++ b/src/test/java/codesquad/web/QuestionAcceptanceTest.java
@@ -92,7 +92,6 @@ public class QuestionAcceptanceTest extends AcceptanceTest {
         ResponseEntity<String> response = basicAuthTemplate().postForEntity(String.format("/questions/%d", defaultQuestion().getId()), request, String.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
-        assertThat(response.getHeaders().getLocation().getPath()).startsWith("/questions");
     }
 
     @Test


### PR DESCRIPTION
요구사항

**질문 삭제 기능 구현**

* 질문 데이터를 삭제 상태로 변경
  * 그럼 삭제가 가능한 경우는?
    * 로그인 사용자와 질문한 사람이 같은 경우
      * 답변이 없는 경우
      * 질문자와 답변 글의 모든 답변자 같은 경우 
* 질문을 삭제할 때 답변 또한 삭제해야 하며, 답변의 삭제 또한 삭제 상태로 변경
  * 그럼 삭제가 가능한 경우?
    * 질문자와 답변자가 다른 경우 답변을 삭제할 수 없다.
* 질문과 답변 삭제 이력에 대한 정보를 DeleteHistory를 활용해 남긴다.



User, Question, Answer 협력을 통한 구현



AcceptanceTest는 클라이언트 관점에서 응답으로 받을 수 있는 경우에 대한 테스트이기 때문에 

* 질문을 정상적으로 삭제할 수 있는 경우
* 질문을 삭제할 수 없는 경우로 나눈다.

질문 삭제에 대한 조건은 단위테스트로 작성한다.



비즈니스 로직이 변경되더라도 기존 테스트 코드는 통과해야함으로 테스트 코드의 수정이 아닌 비즈니스 로직을 수정한다.



[질문 삭제 기능 구현 세부사항]// 순서
1. 해당 질문 찾기
2. 질문 삭제 가능 여부 판단
2 - 1. 해당 질문의 작성자와 로그인한 사람이 일치하는지 판단
2 - 2. 로그인한 사람과 모든 답변의 작성자가 같은지 판단
3. 답변의 삭제 상태가 모두 삭제인지 아닌지 판단
4. 삭제일 경우 질문도 삭제 상태로 변경